### PR TITLE
service: change WantedBy to generic target

### DIFF
--- a/evremap.service
+++ b/evremap.service
@@ -7,5 +7,5 @@ ExecStart=bash -c "/usr/bin/evremap remap /etc/evremap/remap.toml"
 Restart=always
 
 [Install]
-WantedBy=gdm.service
+WantedBy=multi-user.target
 


### PR DESCRIPTION
Instead of relying on the user having GDM installed, switch to the generic systemd `multi-user.target`.